### PR TITLE
Changed git commit message guide

### DIFF
--- a/protocol/git/README.md
+++ b/protocol/git/README.md
@@ -50,7 +50,7 @@ Write a [good commit message]. Example format:
     * More information about commit (under 72 characters).
     * More information about commit (under 72 characters).
 
-    http://project.management-system.com/ticket/123
+    [Trello #<trello-ticket-no>](https://trello.com/c/<trello-ticket-alphanumerical-id>)
 
 If you've created more than one commit,
 [use `git rebase` interactively](https://help.github.com/articles/about-git-rebase/)


### PR DESCRIPTION
- specified format of trello ticket links