### PR TITLE
disable unfreeze string cop

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -577,6 +577,10 @@ Performance/StringReplacement:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
   Enabled: false
 
+Performance/UnfreezeString:
+  Description: 'Use unary plus to get an unfrozen string literal.'
+  Enabled: false
+  
 # Rails
 
 Rails/ActionFilter:


### PR DESCRIPTION
disables the cop as it suggests a way to unfreeze strings in a way that
we feel is not explicit enough.